### PR TITLE
Cambiar EPPlus por ClosedXML para reportes de Excel

### DIFF
--- a/Presentation.WpfApp/Presentation.WpfApp.csproj
+++ b/Presentation.WpfApp/Presentation.WpfApp.csproj
@@ -44,7 +44,6 @@
 		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.15.1" />
 		<PackageReference Include="Caliburn.Micro" Version="4.0.212" />
-		<PackageReference Include="EPPlus" Version="4.5.3.3" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.9" />
 		<PackageReference Include="MahApps.Metro.IconPacks.FontAwesome" Version="4.11.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />

--- a/Presentation.WpfApp/Presentation.WpfApp.csproj
+++ b/Presentation.WpfApp/Presentation.WpfApp.csproj
@@ -44,6 +44,7 @@
 		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.15.1" />
 		<PackageReference Include="Caliburn.Micro" Version="4.0.212" />
+		<PackageReference Include="ClosedXML" Version="0.100.3" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.9" />
 		<PackageReference Include="MahApps.Metro.IconPacks.FontAwesome" Version="4.11.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />

--- a/Presentation.WpfApp/ViewModels/Cfdis/ListaCfdisViewModel.cs
+++ b/Presentation.WpfApp/ViewModels/Cfdis/ListaCfdisViewModel.cs
@@ -1,12 +1,11 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
-using System.IO;
 using System.Windows.Data;
 using Caliburn.Micro;
+using ClosedXML.Excel;
 using Core.Application.Cfdis.Models;
 using MahApps.Metro.Controls.Dialogs;
 using Microsoft.Win32;
-using OfficeOpenXml;
 
 namespace Presentation.WpfApp.ViewModels.Cfdis;
 
@@ -77,12 +76,11 @@ public sealed class ListaCfdisViewModel : Screen
 
         try
         {
-            using (var excelPackage = new ExcelPackage(new FileInfo(saveFileDialog.FileName)))
+            using (var workbook = new XLWorkbook())
             {
-                ExcelWorksheet excelWorksheet = excelPackage.Workbook.Worksheets.Add("CFDIs");
-                excelWorksheet.Cells.LoadFromCollection(ComprobantesView.Cast<CfdiEncabezadoDto>(), true);
-                excelWorksheet.Cells.AutoFitColumns();
-                excelPackage.Save();
+                IXLWorksheet worksheet = workbook.Worksheets.Add("CFDIs");
+                worksheet.Cell(1, 1).InsertData(ComprobantesView.Cast<CfdiEncabezadoDto>().AsEnumerable());
+                workbook.SaveAs(saveFileDialog.FileName);
             }
 
             Process.Start(new ProcessStartInfo(saveFileDialog.FileName) { UseShellExecute = true });


### PR DESCRIPTION
Cambiar la libreria EPPLUS a ClosedXML ya que la version de EPPLUS es muy vieja y se necesita una licencia para actualizar a la nueva.

